### PR TITLE
fix: apply text-balance to event titles and summaries

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -243,11 +243,11 @@ const timelineSchema = {
                         </span>
                       </div>
                       <h2
-                        class={`timeline-title mt-4 text-[1.7rem] font-medium leading-[1.14] text-[var(--ink)] md:text-[1.8rem] ${isLeft ? "md:ml-auto" : ""}`}
+                        class={`timeline-title mt-4 text-[1.7rem] text-balance font-medium leading-[1.14] text-[var(--ink)] md:text-[1.8rem] ${isLeft ? "md:ml-auto" : ""}`}
                       >
                         {event.title}
                       </h2>
-                      <p class="mt-4 text-base leading-7 text-[var(--ink-soft)]">
+                      <p class="mt-4 text-base leading-7 text-balance text-[var(--ink-soft)]">
                         {event.summary}
                       </p>
                       <div class={`mt-5 flex flex-wrap gap-2 ${isLeft ? "md:justify-end" : ""}`}>


### PR DESCRIPTION
Before:

<img width="1535" height="1338" alt="Screenshot 2026-04-27 at 3 54 16 PM" src="https://github.com/user-attachments/assets/e516684c-7b9f-440d-b3e0-3577cbe2e115" />

---

After:

<img width="1535" height="1338" alt="Screenshot 2026-04-27 at 3 54 28 PM" src="https://github.com/user-attachments/assets/cc5bc873-db32-4073-a4d3-8442a8a8fa03" />
