### PR TITLE
Fix timeline order button semantics

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -175,7 +175,6 @@ const timelineSchema = {
               id="timeline-order-toggle"
               type="button"
               class="timeline-order-button ui-text"
-              aria-pressed="true"
               data-order="newest"
             >
               Oldest first
@@ -411,7 +410,6 @@ const timelineSchema = {
         }
 
         orderToggle.setAttribute("data-order", order);
-        orderToggle.setAttribute("aria-pressed", String(isNewest));
         orderToggle.textContent = isNewest ? "Oldest first" : "Newest first";
       };
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -242,7 +242,7 @@ a:focus-visible {
   outline-offset: 4px;
 }
 
-.timeline-order-button[aria-pressed="true"] {
+.timeline-order-button[data-order="newest"] {
   color: color-mix(in srgb, var(--accent-dark) 60%, transparent);
 }
 


### PR DESCRIPTION
## Summary

Fix the timeline order button so it does not expose a misleading pressed state to assistive technology.

## Details

The button text describes the next action available to the user: "Oldest first" when the timeline is currently newest-first, and "Newest first" after the order is changed. Because the label is action-oriented rather than state-oriented, `aria-pressed` made the control announce a toggle state that did not match the visible text.

This removes the `aria-pressed` attribute updates and keeps the visual styling tied to the existing `data-order` state instead.

## Validation

- `bun run lint`
- `bun run build`
