### PR TITLE
Use Astro site config for metadata URLs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,6 +2,7 @@ import { defineConfig } from "astro/config";
 import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
+  site: "https://clawd.rip",
   vite: {
     plugins: [tailwindcss()],
   },

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -40,26 +40,26 @@ const displayedTimelineEvents = [...timelineEvents].reverse();
 const siteTitle = "Everything That Went Wrong With Claude";
 const siteDescription =
   "A satirical timeline of Claude and Anthropic controversies, outages, bans, legal disputes, policy fights, and quality complaints.";
-const siteUrl = "https://clawd.rip/";
-const previewImage = `${siteUrl}og-image.png`;
+const siteUrl = Astro.site ?? new URL("https://clawd.rip");
+const previewImage = new URL("/og-image.png", siteUrl);
 const timelineSchema = {
   "@context": "https://schema.org",
   "@type": "ItemList",
   name: siteTitle,
   description: siteDescription,
-  url: siteUrl,
+  url: siteUrl.toString(),
   numberOfItems: timelineEvents.length,
   itemListElement: timelineEvents.map((event, index) => ({
     "@type": "ListItem",
     position: index + 1,
-    url: `${siteUrl}#event-${index + 1}`,
+    url: new URL(`#event-${index + 1}`, siteUrl).toString(),
     item: {
       "@type": "Article",
       headline: event.title,
       description: event.summary,
       datePublished: event.date,
       articleSection: event.category,
-      mainEntityOfPage: `${siteUrl}#event-${index + 1}`,
+      mainEntityOfPage: new URL(`#event-${index + 1}`, siteUrl).toString(),
       citation: event.sources.map((source) => source.url),
     },
   })),


### PR DESCRIPTION
## Summary

Move the deployed site URL into Astro's `site` config and use `Astro.site` when generating canonical, social image, and JSON-LD URLs.

## Why

Astro documents the top-level `site` option as the place to configure the final deployed URL for a project. The docs note that Astro uses this value for generated sitemap and canonical URLs, and that `Astro.site` is available in components for generating absolute URLs.

This page already needs the deployed URL for canonical metadata, Open Graph/Twitter images, and timeline JSON-LD entries. Keeping that URL in `astro.config.mjs` makes the deployment URL part of the framework configuration instead of a page-local hardcoded string.

Astro docs:

- https://docs.astro.build/en/reference/configuration-reference/#site
- https://docs.astro.build/en/reference/api-reference/#astrosite

## What changed

- Added `site: "https://clawd.rip"` to `astro.config.mjs`.
- Replaced the local hardcoded site URL in `src/pages/index.astro` with `Astro.site`.
- Kept the rendered canonical, Open Graph, Twitter image, and JSON-LD URLs unchanged.

## Validation

- `bun run lint`
- `bun run build`
- Checked generated metadata URLs in `dist/index.html`.