### PR TITLE
Timeline polish, click physics easter eggs, and dark mode

### DIFF
--- a/src/components/BottomSection.astro
+++ b/src/components/BottomSection.astro
@@ -29,6 +29,8 @@
       </svg>
       <img
         src="/anthropicdead-light.png"
+        data-light-src="/anthropicdead-light.png"
+        data-dark-src="/anthropicdead-dark.png"
         alt=""
         class="closing-image"
         width="1200"

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,7 +1,10 @@
 <footer class="bg-(--surface)">
   <div
-    class="mx-auto flex max-w-352 justify-center px-6 pb-8 pt-0 sm:px-10 lg:px-20"
+    class="mx-auto flex max-w-352 flex-col items-center gap-4 px-6 pb-8 pt-0 sm:px-10 lg:px-20"
   >
+    <p class="ui-text text-xs text-(--muted)">
+      press <kbd class="dark-kbd">D</kbd> to pay respects in the dark
+    </p>
     <nav
       class="flex items-center justify-center gap-5"
       aria-label="Social links"

--- a/src/components/FunFx.astro
+++ b/src/components/FunFx.astro
@@ -1,0 +1,291 @@
+<div id="fx-layer" aria-hidden="true"></div>
+<script>
+  const root = document.documentElement;
+  const layer = document.getElementById("fx-layer");
+  const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+
+  const syncDarkAssets = (dark: boolean) => {
+    const themeMeta = document.querySelector('meta[name="theme-color"]');
+    themeMeta?.setAttribute("content", dark ? "#1f1d19" : "#faf9f5");
+    const closing = document.querySelector(".closing-image");
+    if (closing instanceof HTMLImageElement) {
+      const next = dark ? closing.dataset.darkSrc : closing.dataset.lightSrc;
+      if (next) closing.src = next;
+    }
+  };
+
+  const setTheme = (dark: boolean) => {
+    root.classList.toggle("dark", dark);
+    syncDarkAssets(dark);
+    try {
+      localStorage.setItem("clawd-theme", dark ? "dark" : "light");
+    } catch {
+      /* localStorage unavailable */
+    }
+  };
+
+  syncDarkAssets(root.classList.contains("dark"));
+
+  window.addEventListener("keydown", (event) => {
+    if (event.key !== "d" && event.key !== "D") return;
+    if (event.metaKey || event.ctrlKey || event.altKey || event.repeat) return;
+    const target = event.target;
+    if (
+      target instanceof HTMLElement &&
+      (target.isContentEditable ||
+        /^(input|textarea|select)$/i.test(target.tagName))
+    ) {
+      return;
+    }
+    setTheme(!root.classList.contains("dark"));
+  });
+
+  type Particle = {
+    el: HTMLElement;
+    x: number;
+    y: number;
+    vx: number;
+    vy: number;
+    rot: number;
+    vr: number;
+    size: number;
+    rest: number;
+    age: number;
+    life: number;
+    fading: boolean;
+  };
+
+  const particles = new Set<Particle>();
+  let rafId = 0;
+  let lastTime = 0;
+
+  const rand = (min: number, max: number) => min + Math.random() * (max - min);
+  const pick = <T,>(options: readonly T[]) =>
+    options[Math.floor(Math.random() * options.length)];
+
+  const step = (now: number) => {
+    const dt = Math.min((now - lastTime) / 1000, 0.05);
+    lastTime = now;
+    const floor = window.innerHeight;
+    const right = window.innerWidth;
+
+    for (const p of particles) {
+      p.age += dt;
+      p.vy += 2300 * dt;
+      p.x += p.vx * dt;
+      p.y += p.vy * dt;
+      p.rot += p.vr * dt;
+
+      if (p.y + p.size > floor) {
+        p.y = floor - p.size;
+        if (Math.abs(p.vy) > 90) {
+          p.vy = -Math.abs(p.vy) * p.rest;
+          p.vx *= 0.82;
+          p.vr *= 0.7;
+        } else {
+          p.vy = 0;
+          p.vx *= 0.92;
+          p.vr *= 0.9;
+        }
+      }
+      if (p.x < 0) {
+        p.x = 0;
+        p.vx = Math.abs(p.vx) * 0.6;
+      } else if (p.x + p.size > right) {
+        p.x = right - p.size;
+        p.vx = -Math.abs(p.vx) * 0.6;
+      }
+
+      if (p.age > p.life && !p.fading) {
+        p.fading = true;
+        p.el.style.opacity = "0";
+      }
+      if (p.age > p.life + 0.45) {
+        p.el.remove();
+        particles.delete(p);
+        continue;
+      }
+      p.el.style.transform = `translate(${p.x}px, ${p.y}px) rotate(${p.rot}deg)`;
+    }
+
+    rafId = particles.size ? requestAnimationFrame(step) : 0;
+  };
+
+  const startLoop = () => {
+    if (!rafId) {
+      lastTime = performance.now();
+      rafId = requestAnimationFrame(step);
+    }
+  };
+
+  type ParticleSeed = { node: HTMLElement; size: number };
+
+  const spawn = (
+    seed: ParticleSeed,
+    x: number,
+    y: number,
+    vx: number,
+    vy: number,
+  ) => {
+    if (!layer || reduceMotion.matches || particles.size >= 90) return;
+    const { node, size } = seed;
+    node.classList.add("fx-particle");
+    node.style.width = `${size}px`;
+    node.style.height = `${size}px`;
+    layer.append(node);
+    particles.add({
+      el: node,
+      x: x - size / 2,
+      y: y - size / 2,
+      vx,
+      vy,
+      rot: rand(-30, 30),
+      vr: rand(-420, 420),
+      size,
+      rest: rand(0.45, 0.62),
+      age: 0,
+      life: rand(3.2, 4.4),
+      fading: false,
+    });
+    startLoop();
+  };
+
+  const blockColors = ["#d97757", "#c25e3a", "#8e3f2f", "#e08862"];
+
+  const makeBlock = (): ParticleSeed => {
+    const node = document.createElement("div");
+    node.style.background = pick(blockColors);
+    return { node, size: rand(7, 16) };
+  };
+
+  const makeX = (): ParticleSeed => {
+    const node = document.createElement("div");
+    node.textContent = "✕";
+    node.style.color = "var(--accent)";
+    node.style.fontWeight = "700";
+    node.style.fontFamily = "Arial, Helvetica, sans-serif";
+    const size = rand(14, 22);
+    node.style.fontSize = `${size}px`;
+    node.style.lineHeight = "1";
+    return { node, size };
+  };
+
+  const iconPools = ["legal", "quality", "reliability", "policy"];
+
+  const makeIcon = (category: string | null): ParticleSeed => {
+    const pool =
+      category && iconPools.includes(category) ? category : pick(iconPools);
+    const img = document.createElement("img");
+    img.src = `/incident-layers/${pool}-${Math.floor(Math.random() * 9)}.avif`;
+    img.alt = "";
+    const node = document.createElement("div");
+    node.append(img);
+    return { node, size: rand(26, 46) };
+  };
+
+  const burst = (x: number, y: number, seeds: (() => ParticleSeed)[]) => {
+    for (const make of seeds) {
+      spawn(make(), x + rand(-8, 8), y + rand(-8, 8), rand(-280, 280), rand(-680, -260));
+    }
+  };
+
+  const rain = (count: number, category: string | null) => {
+    for (let i = 0; i < count; i++) {
+      spawn(
+        makeIcon(category),
+        rand(20, Math.max(40, window.innerWidth - 20)),
+        -60,
+        rand(-60, 60),
+        rand(0, 140),
+      );
+    }
+  };
+
+  const replayAnimation = (el: Element, className: string) => {
+    if (reduceMotion.matches) return;
+    el.classList.remove(className);
+    void el.getBoundingClientRect();
+    el.classList.add(className);
+  };
+
+  const clickCounts = new Map<string, number>();
+  const bump = (key: string) => {
+    const next = (clickCounts.get(key) ?? 0) + 1;
+    clickCounts.set(key, next);
+    return next;
+  };
+
+  const categoryOf = (el: Element) =>
+    el.closest("[data-category]")?.getAttribute("data-category")?.toLowerCase() ??
+    null;
+
+  document.addEventListener("click", (event) => {
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    const x = event.clientX;
+    const y = event.clientY;
+
+    const correction = target.closest(".hero-correction");
+    if (correction) {
+      correction.classList.toggle("is-flipped");
+      burst(x, y, [makeX]);
+      return;
+    }
+
+    const heroArt = target.closest(".hero-pixel-art");
+    if (heroArt) {
+      replayAnimation(heroArt, "fx-wobble");
+      const clicks = bump("hero");
+      const seeds: (() => ParticleSeed)[] = Array.from(
+        { length: Math.min(5 + clicks * 2, 16) },
+        () => makeBlock,
+      );
+      seeds.push(makeX, makeX);
+      burst(x, y, seeds);
+      if (clicks % 8 === 0) rain(8 + Math.min(clicks, 16), null);
+      return;
+    }
+
+    const marker = target.closest(".timeline-marker, .timeline-marker-mobile");
+    if (marker) {
+      replayAnimation(marker, "fx-spin");
+      const category = categoryOf(marker);
+      const clicks = bump("markers");
+      const seeds: (() => ParticleSeed)[] = [
+        makeX,
+        makeX,
+        makeX,
+        () => makeIcon(category),
+      ];
+      if (clicks > 5) seeds.push(() => makeIcon(category));
+      burst(x, y, seeds);
+      return;
+    }
+
+    const chip = target.closest(".timeline-meta-category");
+    if (chip) {
+      replayAnimation(chip, "fx-wobble");
+      burst(x, y, [() => makeIcon(categoryOf(chip)), makeX]);
+      return;
+    }
+
+    const closing = target.closest(".closing-image");
+    if (closing) {
+      replayAnimation(closing, "fx-wobble");
+      const clicks = bump("closing");
+      burst(
+        x,
+        y,
+        Array.from({ length: Math.min(3 + clicks, 10) }, () => makeX),
+      );
+      if (clicks % 6 === 0) rain(10, null);
+      return;
+    }
+
+    const affiliate = target.closest(".affiliate-note");
+    if (affiliate) {
+      replayAnimation(affiliate, "fx-wobble");
+      burst(x, y, [makeX, makeX, makeX]);
+    }
+  });
+</script>

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -65,5 +65,16 @@ const timelineSchema = {
     is:inline
     set:html={JSON.stringify(timelineSchema)}
   />
+  <script is:inline>
+    try {
+      if (localStorage.getItem("clawd-theme") === "dark") {
+        document.documentElement.classList.add("dark");
+        var themeMeta = document.querySelector('meta[name="theme-color"]');
+        if (themeMeta) themeMeta.setAttribute("content", "#1f1d19");
+      }
+    } catch {
+      /* localStorage unavailable */
+    }
+  </script>
   <title>{siteTitle}</title>
 </head>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -36,7 +36,7 @@
       <img
         src="/brand/anthropic-wordmark.svg"
         alt="Anthropic"
-        class="h-2.5 w-auto opacity-70"
+        class="affiliate-wordmark h-2.5 w-auto opacity-70"
         width="182"
         height="24"
       />

--- a/src/components/Timeline.astro
+++ b/src/components/Timeline.astro
@@ -7,15 +7,15 @@ type TimelineCategory = TimelineEvent["category"];
 
 const categoryStyles = {
   Legal:
-    "border-[color-mix(in_srgb,var(--accent-dark)_50%,transparent)] text-[color-mix(in_srgb,var(--accent-dark)_60%,transparent)]",
+    "border-[color-mix(in_srgb,var(--cat-legal)_45%,transparent)] bg-[color-mix(in_srgb,var(--cat-legal)_6%,transparent)] text-[color-mix(in_srgb,var(--cat-legal)_72%,transparent)]",
   Quality:
-    "border-[color-mix(in_srgb,#7a5636_50%,transparent)] text-[color-mix(in_srgb,#7a5636_60%,transparent)]",
+    "border-[color-mix(in_srgb,var(--cat-quality)_45%,transparent)] bg-[color-mix(in_srgb,var(--cat-quality)_6%,transparent)] text-[color-mix(in_srgb,var(--cat-quality)_72%,transparent)]",
   Reliability:
-    "border-[color-mix(in_srgb,#506047_50%,transparent)] text-[color-mix(in_srgb,#506047_60%,transparent)]",
+    "border-[color-mix(in_srgb,var(--cat-reliability)_45%,transparent)] bg-[color-mix(in_srgb,var(--cat-reliability)_6%,transparent)] text-[color-mix(in_srgb,var(--cat-reliability)_72%,transparent)]",
   Safety:
-    "border-[color-mix(in_srgb,#7c4636_50%,transparent)] text-[color-mix(in_srgb,#7c4636_60%,transparent)]",
+    "border-[color-mix(in_srgb,var(--cat-safety)_45%,transparent)] bg-[color-mix(in_srgb,var(--cat-safety)_6%,transparent)] text-[color-mix(in_srgb,var(--cat-safety)_72%,transparent)]",
   Policy:
-    "border-[color-mix(in_srgb,#665744_50%,transparent)] text-[color-mix(in_srgb,#665744_60%,transparent)]",
+    "border-[color-mix(in_srgb,var(--cat-policy)_45%,transparent)] bg-[color-mix(in_srgb,var(--cat-policy)_6%,transparent)] text-[color-mix(in_srgb,var(--cat-policy)_72%,transparent)]",
 } as const;
 
 const incidentLayerGroups = {
@@ -82,7 +82,7 @@ const displayedTimelineEvents = [...timelineEvents].reverse();
     </div>
     <div class="relative">
       <div
-        class="absolute bottom-0 left-2.75 top-4.25 w-px bg-[color-mix(in_srgb,var(--line)_80%,var(--ink-soft))] md:left-1/2 md:-translate-x-1/2"
+        class="timeline-spine absolute bottom-0 left-2.75 top-4.25 md:left-1/2 md:-translate-x-1/2"
         aria-hidden="true"
       >
       </div>
@@ -98,10 +98,15 @@ const displayedTimelineEvents = [...timelineEvents].reverse();
                 data-timeline-entry
                 class="timeline-entry relative pb-16 pl-10 md:pl-0"
               >
-                <div
-                  class="timeline-marker absolute left-[0.4rem] top-2.25 z-10 h-4 w-4 rounded-full border border-(--accent) bg-(--surface) md:left-1/2 md:-translate-x-1/2"
+                <svg
+                  class="timeline-marker absolute left-[0.4rem] top-2.25 z-10 h-4 w-4 md:left-1/2 md:-translate-x-1/2"
+                  viewBox="0 0 16 16"
                   aria-hidden="true"
-                ></div>
+                >
+                  <circle cx="8" cy="8" r="8"></circle>
+                  <path d="M3.4 3.9 Q8 7.3 12.8 12.4"></path>
+                  <path d="M12.5 3.4 Q8.2 7.9 3.6 12.7"></path>
+                </svg>
                 <figure class="timeline-visual" aria-hidden="true">
                   {layers.map((layer, layerIndex) => (
                     <img
@@ -116,12 +121,17 @@ const displayedTimelineEvents = [...timelineEvents].reverse();
                   ))}
                 </figure>
                 <article class="timeline-content relative">
-                  <div
-                    class="timeline-marker-mobile absolute -left-9.25 top-[0.53125rem] z-10 h-4 w-4 rounded-full border border-(--accent) bg-(--surface) md:hidden"
+                  <svg
+                    class="timeline-marker-mobile absolute -left-9.25 top-[0.53125rem] z-10 h-4 w-4 md:hidden"
+                    viewBox="0 0 16 16"
                     aria-hidden="true"
-                  ></div>
+                  >
+                    <circle cx="8" cy="8" r="8"></circle>
+                    <path d="M3.4 3.9 Q8 7.3 12.8 12.4"></path>
+                    <path d="M12.5 3.4 Q8.2 7.9 3.6 12.7"></path>
+                  </svg>
                   <div
-                    class="timeline-branch absolute -left-8 top-[1.03125rem] h-px w-8 bg-[color-mix(in_srgb,var(--line)_80%,var(--ink-soft))]"
+                    class="timeline-branch absolute -left-8 top-[1.03125rem] w-8"
                     aria-hidden="true"
                   ></div>
                   <div class="timeline-meta">
@@ -132,7 +142,7 @@ const displayedTimelineEvents = [...timelineEvents].reverse();
                       {event.period}
                     </time>
                     <span
-                      class={`timeline-meta-category ui-text inline-flex items-center rounded-full border bg-transparent px-2.5 py-px text-sm font-medium leading-4 ${categoryStyles[event.category]}`}
+                      class={`timeline-meta-category ui-text inline-flex items-center rounded-full border px-2.5 py-px text-sm font-medium leading-4 ${categoryStyles[event.category]}`}
                     >
                       {event.category}
                     </span>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,6 @@
 ---
 import "../styles/global.css";
+import FunFx from "@/components/FunFx.astro";
 import Head from "@/components/Head.astro";
 import Header from "@/components/Header.astro";
 import Footer from "@/components/Footer.astro";
@@ -14,5 +15,6 @@ import Footer from "@/components/Footer.astro";
       <slot />
       <Footer />
     </main>
+    <FunFx />
   </body>
 </html>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -11,7 +11,57 @@
   --accent-dark: #8e3f2f;
   --line: #d8d0c3;
   --line-soft: #e7e0d6;
+  --cat-legal: var(--accent-dark);
+  --cat-quality: #7a5636;
+  --cat-reliability: #506047;
+  --cat-safety: #7c4636;
+  --cat-policy: #665744;
+  --sticker-ink: #ffffff;
+  --sticker-outline: drop-shadow(1.75px 0 0 var(--sticker-ink))
+    drop-shadow(-1.75px 0 0 var(--sticker-ink)) drop-shadow(0 1.75px 0 var(--sticker-ink))
+    drop-shadow(0 -1.75px 0 var(--sticker-ink));
   --site-header-height: 53px;
+}
+
+html.dark {
+  color-scheme: dark;
+  --canvas: #1f1d19;
+  --surface: #282520;
+  --ink: #ece7dd;
+  --ink-soft: #c8bfb1;
+  --muted: #968d80;
+  --accent: #e08862;
+  --accent-dark: #e8a085;
+  --line: #454036;
+  --line-soft: #38342c;
+  --cat-legal: #e09a82;
+  --cat-quality: #d4a878;
+  --cat-reliability: #a3bd94;
+  --cat-safety: #de9b80;
+  --cat-policy: #c2b196;
+}
+
+html.dark ::selection {
+  background: rgba(224, 136, 98, 0.3);
+}
+
+html.dark .brand-wordmark,
+html.dark .affiliate-wordmark {
+  filter: invert(1) hue-rotate(180deg);
+}
+
+html.dark .social-link img.invert {
+  filter: none;
+}
+
+html.dark footer img[src="/source-icons/x.svg"] {
+  filter: invert(1);
+}
+
+html.dark .timeline-sources a img {
+  border-radius: 3px;
+  background: #faf9f5;
+  box-shadow: 0 0 0 2px #faf9f5;
 }
 
 * {
@@ -95,7 +145,7 @@ a:focus-visible {
   display: block;
   width: 48%;
   height: auto;
-  filter: drop-shadow(0 0.45rem 0.9rem rgba(20, 20, 19, 0.07));
+  filter: var(--sticker-outline) drop-shadow(0 0.45rem 0.9rem rgba(20, 20, 19, 0.07));
   object-fit: contain;
   transform-origin: 50% 65%;
   will-change: opacity, filter, transform;
@@ -188,12 +238,14 @@ a:focus-visible {
   transform-origin: center;
 }
 
-.hero-correction:hover .hero-struck {
+.hero-correction:hover .hero-struck,
+.hero-correction.is-flipped .hero-struck {
   opacity: 0;
   transform: translateY(-0.08em);
 }
 
-.hero-correction:hover .hero-insert {
+.hero-correction:hover .hero-insert,
+.hero-correction.is-flipped .hero-insert {
   opacity: 1;
   transform: translateY(0) scale(1);
 }
@@ -212,6 +264,146 @@ a:focus-visible {
 
 .timeline-toolbar {
   min-height: 1.5rem;
+}
+
+.timeline-spine {
+  width: 2px;
+  background-image: repeating-linear-gradient(
+    to bottom,
+    color-mix(in srgb, var(--line) 80%, var(--ink-soft)) 0,
+    color-mix(in srgb, var(--line) 80%, var(--ink-soft)) 6px,
+    transparent 6px,
+    transparent 12px
+  );
+  mask-image: linear-gradient(
+    to bottom,
+    transparent,
+    black 2.5rem,
+    black calc(100% - 5rem),
+    transparent
+  );
+}
+
+.timeline-branch {
+  height: 2px;
+  background-image: repeating-linear-gradient(
+    to right,
+    color-mix(in srgb, var(--line) 80%, var(--ink-soft)) 0,
+    color-mix(in srgb, var(--line) 80%, var(--ink-soft)) 6px,
+    transparent 6px,
+    transparent 12px
+  );
+}
+
+.timeline-marker,
+.timeline-marker-mobile {
+  overflow: visible;
+}
+
+.timeline-marker circle,
+.timeline-marker-mobile circle {
+  fill: var(--surface);
+}
+
+.timeline-marker path,
+.timeline-marker-mobile path {
+  fill: none;
+  stroke: var(--accent);
+  stroke-width: 2.4;
+  stroke-linecap: round;
+}
+
+.timeline-entry:nth-child(odd) .timeline-marker,
+.timeline-entry:nth-child(odd) .timeline-marker-mobile {
+  rotate: -8deg;
+}
+
+.timeline-entry:nth-child(even) .timeline-marker,
+.timeline-entry:nth-child(even) .timeline-marker-mobile {
+  rotate: 9deg;
+}
+
+.timeline-sources a:hover {
+  transform: translateY(-1.5px);
+  box-shadow: 0 2px 0 color-mix(in srgb, var(--line) 70%, transparent);
+}
+
+#fx-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.fx-particle {
+  position: absolute;
+  left: 0;
+  top: 0;
+  user-select: none;
+  will-change: transform;
+  transition: opacity 420ms ease;
+}
+
+.fx-particle img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  filter: var(--sticker-outline);
+}
+
+.hero-pixel-art,
+.closing-image,
+.timeline-marker,
+.timeline-marker-mobile,
+.timeline-meta-category {
+  cursor: pointer;
+}
+
+@keyframes fx-wobble {
+  0% {
+    rotate: 0deg;
+    scale: 1;
+  }
+  25% {
+    rotate: -4deg;
+    scale: 0.96;
+  }
+  55% {
+    rotate: 3deg;
+    scale: 1.04;
+  }
+  100% {
+    rotate: 0deg;
+    scale: 1;
+  }
+}
+
+.fx-wobble {
+  animation: fx-wobble 420ms ease;
+}
+
+@keyframes fx-spin {
+  from {
+    rotate: 0deg;
+  }
+  to {
+    rotate: 360deg;
+  }
+}
+
+.fx-spin {
+  animation: fx-spin 480ms cubic-bezier(0.34, 1.3, 0.64, 1);
+}
+
+.dark-kbd {
+  padding: 0 0.4em;
+  border: 1px solid var(--line);
+  border-bottom-width: 2px;
+  border-radius: 4px;
+  background: var(--canvas);
+  font: inherit;
 }
 
 .timeline-order-button {
@@ -290,7 +482,7 @@ a:focus-visible {
 
 .closing-handwriting-small,
 .closing-handwriting-large {
-  fill: hsl(0, 0%, 10%);
+  fill: var(--ink);
   font-family: "Bradley Hand", "Comic Sans MS", "Comic Sans", "Marker Felt", cursive;
   font-weight: 400;
   letter-spacing: 0;
@@ -315,13 +507,28 @@ a:focus-visible {
 
   .incident-layer {
     opacity: 0;
-    filter: blur(7px) drop-shadow(0 0.45rem 0.9rem rgba(20, 20, 19, 0.07));
+    filter: var(--sticker-outline) blur(7px) drop-shadow(0 0.45rem 0.9rem rgba(20, 20, 19, 0.07));
     transform: translateY(var(--layer-y)) scale(0.94) rotate(calc(var(--layer-rotate) * 0.25));
     transition:
       opacity 620ms ease,
       transform 820ms cubic-bezier(0.22, 1, 0.36, 1),
       filter 820ms cubic-bezier(0.22, 1, 0.36, 1);
     transition-delay: calc(var(--layer-index) * 95ms);
+  }
+
+  .timeline-marker,
+  .timeline-marker-mobile {
+    opacity: 0;
+    scale: 0.35;
+    transition:
+      scale 560ms cubic-bezier(0.34, 1.56, 0.64, 1) 120ms,
+      opacity 240ms ease 120ms;
+  }
+
+  .timeline-entry.is-visible .timeline-marker,
+  .timeline-entry.is-visible .timeline-marker-mobile {
+    opacity: 1;
+    scale: 1;
   }
 
   .timeline-entry.is-visible .timeline-visual {
@@ -331,7 +538,7 @@ a:focus-visible {
 
   .timeline-entry.is-visible .incident-layer {
     opacity: 0.96;
-    filter: blur(0) drop-shadow(0 0.45rem 0.9rem rgba(20, 20, 19, 0.07));
+    filter: var(--sticker-outline) blur(0) drop-shadow(0 0.45rem 0.9rem rgba(20, 20, 19, 0.07));
     transform: translateY(0) scale(1) rotate(var(--layer-rotate));
   }
 }


### PR DESCRIPTION
## What's in here

### Timeline polish
- Round markers replaced with hand-drawn ✕ marks (echoing the pixel-art X eyes), alternating tilt, springy stamp-in pop on scroll reveal
- Dashed sketchy spine that fades in at the top and trails off at the bottom; matching dashed branch connectors
- Category chips get a faint tinted fill (readable at a glance, still soft); source chips lift with a flat comic shadow on hover

### Click physics easter eggs (`FunFx.astro`)
Small custom physics engine (gravity, floor/wall bounces, spin, 90-particle cap, `prefers-reduced-motion` aware):
- Pixel-art Claude bursts orange pixel blocks — escalates with repeated clicks, icon rain every 8th
- ✕ markers spin and pop incident icons matching the event category
- Category chips, stick figures, and the "not affiliated" note all wobble and spit ✕s
- Tapping the "went/is" headline correction toggles it (mobile gets the joke too)

### Dark mode (press **D**)
- Warm charcoal palette tuned to the terracotta accent; instant switch, persisted in localStorage, applied pre-paint (no flash), `theme-color` meta kept in sync
- Closing artwork swaps to the dark variant; monochrome wordmarks invert; source favicons sit on small light plates so dark logos (GitHub, Wired, FT…) stay visible without breaking colored ones
- Discoverable via footer hint: *press D to pay respects in the dark*

### Sticker outlines
Incident illustrations get a cartoonish white die-cut outline (stacked drop-shadows) in both themes — fixes dark-on-dark imagery and leans into the comic collage style.

## Verification
- Tested in headless Chromium at desktop + mobile viewports, both themes, both toggle directions (no gradient-band glitch)
- Order toggle still reorders correctly; links unaffected by click effects
- `bun run build` (includes `astro check`), `oxlint`, and `oxfmt --check` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dark/light theme toggle (press D key) with persistent user preference.
  * Introduced interactive particle animation effects triggered by UI interactions.
  * Implemented theme-aware image sources for light and dark modes.

* **Style**
  * Enhanced timeline visual styling with updated markers and gradients.
  * Refreshed overall design with improved animations and visual effects.
  * Added playful footer message with adjusted layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->