### PR TITLE
feat: timeline index filters and slash spark effects

### DIFF
--- a/src/components/FunFx.astro
+++ b/src/components/FunFx.astro
@@ -120,14 +120,32 @@
 
   type ParticleSeed = { node: HTMLElement; size: number };
 
+  const PARTICLE_CAP = 90;
+
+  const evictOldestParticle = () => {
+    let oldest: Particle | null = null;
+    for (const particle of particles) {
+      if (!oldest || particle.age > oldest.age) oldest = particle;
+    }
+    if (!oldest) return;
+    oldest.el.remove();
+    particles.delete(oldest);
+  };
+
   const spawn = (
     seed: ParticleSeed,
     x: number,
     y: number,
     vx: number,
     vy: number,
+    options?: { recycleAtCap?: boolean },
   ) => {
-    if (!layer || reduceMotion.matches || particles.size >= 90) return;
+    if (!layer || reduceMotion.matches) return;
+    if (particles.size >= PARTICLE_CAP) {
+      if (options?.recycleAtCap) evictOldestParticle();
+      else return;
+    }
+    if (particles.size >= PARTICLE_CAP) return;
     const { node, size } = seed;
     node.classList.add("fx-particle");
     node.style.width = `${size}px`;
@@ -183,9 +201,21 @@
     return { node, size: rand(26, 46) };
   };
 
-  const burst = (x: number, y: number, seeds: (() => ParticleSeed)[]) => {
+  const burst = (
+    x: number,
+    y: number,
+    seeds: (() => ParticleSeed)[],
+    options?: { recycleAtCap?: boolean },
+  ) => {
     for (const make of seeds) {
-      spawn(make(), x + rand(-8, 8), y + rand(-8, 8), rand(-280, 280), rand(-680, -260));
+      spawn(
+        make(),
+        x + rand(-8, 8),
+        y + rand(-8, 8),
+        rand(-280, 280),
+        rand(-680, -260),
+        options,
+      );
     }
   };
 
@@ -219,11 +249,22 @@
     el.closest("[data-category]")?.getAttribute("data-category")?.toLowerCase() ??
     null;
 
-  document.addEventListener("click", (event) => {
-    const target = event.target;
-    if (!(target instanceof Element)) return;
-    const x = event.clientX;
-    const y = event.clientY;
+  const FX_SELECTOR =
+    ".hero-correction, .hero-pixel-art, .incident-layer, .timeline-marker, .timeline-marker-mobile, .timeline-meta-category, .closing-image, .affiliate-note";
+
+  const resolveFxTarget = (target: EventTarget | null) => {
+    if (!(target instanceof Element)) return null;
+    return target.closest(FX_SELECTOR);
+  };
+
+  for (const img of document.querySelectorAll(
+    ".hero-pixel-art, .closing-image, .incident-layer",
+  )) {
+    if (img instanceof HTMLImageElement) img.draggable = false;
+  }
+
+  const applyFx = (target: Element, x: number, y: number) => {
+    if (reduceMotion.matches) return;
 
     const correction = target.closest(".hero-correction");
     if (correction) {
@@ -246,10 +287,18 @@
       return;
     }
 
+    const layer = target.closest(".incident-layer");
+    if (layer) {
+      replayAnimation(layer, "fx-wobble");
+      const category = categoryOf(layer);
+      burst(x, y, [() => makeIcon(category), makeBlock, makeX]);
+      return;
+    }
+
     const marker = target.closest(".timeline-marker, .timeline-marker-mobile");
     if (marker) {
-      replayAnimation(marker, "fx-spin");
       const category = categoryOf(marker);
+      replayAnimation(marker, "fx-spin");
       const clicks = bump("markers");
       const seeds: (() => ParticleSeed)[] = [
         makeX,
@@ -287,5 +336,162 @@
       replayAnimation(affiliate, "fx-wobble");
       burst(x, y, [makeX, makeX, makeX]);
     }
-  });
+  };
+
+  const SLASH_THRESHOLD = 10;
+  const SLASH_SPAWN_INTERVAL_MS = 50;
+  const SLASH_ANIM_DELAY_MS = 350;
+  const SLASH_ANIM_INTERVAL_MS = 500;
+  const CLICK_THRESHOLD = 6;
+
+  let lastSlashSpawnAt = 0;
+
+  const trySlashBurst = (x: number, y: number) => {
+    const now = performance.now();
+    if (now - lastSlashSpawnAt < SLASH_SPAWN_INTERVAL_MS) return;
+    lastSlashSpawnAt = now;
+    burst(x, y, [makeBlock], { recycleAtCap: true });
+  };
+
+  const replaySlashTilt = (target: Element) => {
+    const correction = target.closest(".hero-correction");
+    if (correction) {
+      correction.classList.toggle("is-flipped");
+      return;
+    }
+
+    const marker = target.closest(".timeline-marker, .timeline-marker-mobile");
+    if (marker) {
+      replayAnimation(marker, "fx-spin");
+      return;
+    }
+
+    const wobbleTarget = target.closest(
+      ".hero-pixel-art, .incident-layer, .timeline-meta-category, .closing-image, .affiliate-note",
+    );
+    if (wobbleTarget) replayAnimation(wobbleTarget, "fx-wobble");
+  };
+
+  type SlashPointer = {
+    id: number;
+    target: Element;
+    lastX: number;
+    lastY: number;
+    totalDist: number;
+    nextAnimAt: number;
+    slashed: boolean;
+  };
+
+  let activeSlash: SlashPointer | null = null;
+  let suppressNextClick = false;
+
+  const maybeSlashAnim = (state: SlashPointer) => {
+    if (!state.slashed) return;
+
+    const now = performance.now();
+    while (now >= state.nextAnimAt) {
+      replaySlashTilt(state.target);
+      state.nextAnimAt += SLASH_ANIM_INTERVAL_MS;
+    }
+  };
+
+  const trackSlashSegment = (
+    x0: number,
+    y0: number,
+    x1: number,
+    y1: number,
+    state: SlashPointer,
+  ) => {
+    const dist = Math.hypot(x1 - x0, y1 - y0);
+    if (dist < 0.5) return;
+
+    state.totalDist += dist;
+
+    if (state.totalDist >= SLASH_THRESHOLD && !state.slashed) {
+      state.slashed = true;
+      state.nextAnimAt = performance.now() + SLASH_ANIM_DELAY_MS;
+    }
+  };
+
+  const endSlash = (event: PointerEvent) => {
+    if (!activeSlash || event.pointerId !== activeSlash.id) return;
+
+    const { target, slashed, totalDist } = activeSlash;
+    if (target.hasPointerCapture(event.pointerId)) {
+      target.releasePointerCapture(event.pointerId);
+    }
+
+    if (slashed) suppressNextClick = true;
+
+    if (!slashed && totalDist < CLICK_THRESHOLD) {
+      applyFx(target, event.clientX, event.clientY);
+    }
+
+    root.classList.remove("fx-slashing");
+    activeSlash = null;
+  };
+
+  document.addEventListener(
+    "click",
+    (event) => {
+      if (!suppressNextClick) return;
+      suppressNextClick = false;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    },
+    true,
+  );
+
+  document.addEventListener(
+    "pointerdown",
+    (event) => {
+      if (event.button !== 0 || reduceMotion.matches) return;
+      const fxTarget = resolveFxTarget(event.target);
+      if (!fxTarget) return;
+
+      event.preventDefault();
+      fxTarget.setPointerCapture(event.pointerId);
+      root.classList.add("fx-slashing");
+
+      activeSlash = {
+        id: event.pointerId,
+        target: fxTarget,
+        lastX: event.clientX,
+        lastY: event.clientY,
+        totalDist: 0,
+        nextAnimAt: Number.POSITIVE_INFINITY,
+        slashed: false,
+      };
+
+      lastSlashSpawnAt = 0;
+    },
+    { passive: false },
+  );
+
+  document.addEventListener(
+    "pointermove",
+    (event) => {
+      if (!activeSlash || event.pointerId !== activeSlash.id) return;
+
+      const { lastX, lastY } = activeSlash;
+      const x = event.clientX;
+      const y = event.clientY;
+      const dist = Math.hypot(x - lastX, y - lastY);
+      if (dist < 1) return;
+
+      if (activeSlash.slashed || activeSlash.totalDist >= SLASH_THRESHOLD) {
+        event.preventDefault();
+      }
+
+      trackSlashSegment(lastX, lastY, x, y, activeSlash);
+      if (activeSlash.slashed) trySlashBurst(x, y);
+      maybeSlashAnim(activeSlash);
+      activeSlash.lastX = x;
+      activeSlash.lastY = y;
+    },
+    { passive: false },
+  );
+
+  document.addEventListener("pointerup", endSlash);
+  document.addEventListener("pointercancel", endSlash);
 </script>

--- a/src/components/Timeline.astro
+++ b/src/components/Timeline.astro
@@ -1,12 +1,16 @@
 ---
 import "../styles/global.css";
 import { timelineEvents } from "@/data/timeline";
-import { categoryStyles, getIncidentLayers } from "@/lib/event-visuals";
+import {
+  categoryStyles,
+  getIncidentLayers,
+  timelineCategories,
+} from "@/lib/event-visuals";
 
 const displayedTimelineEvents = [...timelineEvents].reverse();
 ---
 
-<section class="relative bg-(--surface)">
+<section class="relative bg-(--surface)" id="timeline-section">
   <div
     class="pointer-events-none absolute inset-x-0 top-0 h-24 bg-linear-to-b from-(--canvas) to-(--surface) sm:h-28 lg:h-32"
     aria-hidden="true"
@@ -15,18 +19,68 @@ const displayedTimelineEvents = [...timelineEvents].reverse();
   <div
     class="relative mx-auto w-full max-w-352 overflow-hidden px-6 pb-6 pt-0 sm:px-10 sm:pb-8 lg:px-20"
   >
-    <div
-      class="timeline-toolbar relative z-20 mb-5 flex justify-start md:justify-center"
+    <nav
+      id="timeline-command"
+      class="mb-10 border-t border-dashed border-(--line) pt-6"
+      aria-label="Timeline controls"
     >
-      <button
-        id="timeline-order-toggle"
-        type="button"
-        class="timeline-order-button ui-text"
-        data-order="newest"
+      <div
+        class="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between"
       >
-        Oldest first
-      </button>
-    </div>
+        <p class="ui-text m-0 text-sm leading-6 text-(--ink-soft)">
+          <span class="text-(--muted)">Index</span>
+          <span class="text-(--muted)" aria-hidden="true"> — </span>
+          <span
+            class="inline-flex flex-wrap items-baseline"
+            role="toolbar"
+            aria-label="Filter by category"
+          >
+            <button
+              type="button"
+              class="timeline-filter-link"
+              data-filter="all"
+              aria-pressed="true"
+            >
+              All
+            </button>
+            {
+              timelineCategories.map((category) => (
+                <>
+                  <span class="timeline-filter-sep" aria-hidden="true">
+                    ·
+                  </span>
+                  <button
+                    type="button"
+                    class="timeline-filter-link"
+                    data-filter={category}
+                    data-category={category}
+                    aria-pressed="false"
+                  >
+                    {category}
+                  </button>
+                </>
+              ))
+            }
+          </span>
+        </p>
+
+        <p class="ui-text m-0 flex shrink-0 items-baseline text-sm text-(--muted)">
+          <span id="timeline-filter-status">{timelineEvents.length} incidents</span>
+          <span class="timeline-filter-sep" aria-hidden="true">
+            ·
+          </span>
+          <button
+            id="timeline-order-toggle"
+            type="button"
+            class="timeline-order-button"
+            data-order="newest"
+          >
+            Oldest first
+          </button>
+        </p>
+      </div>
+    </nav>
+
     <div class="relative">
       <div
         class="timeline-spine absolute bottom-0 left-2.75 top-4.25 md:left-1/2 md:-translate-x-1/2"
@@ -146,7 +200,13 @@ const displayedTimelineEvents = [...timelineEvents].reverse();
 </section>
 <script>
   const timeline = document.querySelector("#timeline");
+  const timelineSection = document.querySelector("#timeline-section");
   const orderToggle = document.querySelector("#timeline-order-toggle");
+  const filterButtons = document.querySelectorAll(
+    "#timeline-command [data-filter]",
+  );
+  const filterStatus = document.querySelector("#timeline-filter-status");
+  const emptyState = document.querySelector("#timeline-empty");
   const observedEntries = document.querySelectorAll(".timeline-entry");
   const prefersReducedMotion = window.matchMedia(
     "(prefers-reduced-motion: reduce)",
@@ -173,6 +233,57 @@ const displayedTimelineEvents = [...timelineEvents].reverse();
 
     orderToggle.setAttribute("data-order", order);
     orderToggle.textContent = isNewest ? "Oldest first" : "Newest first";
+    updateAlternatingLayout();
+  };
+
+  const updateAlternatingLayout = () => {
+    if (!timeline) return;
+
+    for (const entry of timelineEntries) {
+      entry.classList.remove("is-alternate-left", "is-alternate-right");
+    }
+
+    const visibleEntries = Array.from(
+      timeline.querySelectorAll(
+        "[data-timeline-entry]:not(.is-filtered-out)",
+      ),
+    ).filter((entry): entry is HTMLElement => entry instanceof HTMLElement);
+
+    for (const [index, entry] of visibleEntries.entries()) {
+      entry.classList.add(
+        index % 2 === 0 ? "is-alternate-left" : "is-alternate-right",
+      );
+    }
+  };
+
+  const applyFilter = (filter: string) => {
+    let visibleCount = 0;
+
+    for (const button of filterButtons) {
+      if (!(button instanceof HTMLButtonElement)) continue;
+      const isActive = button.dataset.filter === filter;
+      button.setAttribute("aria-pressed", String(isActive));
+    }
+
+    for (const entry of timelineEntries) {
+      const category = entry.dataset.category;
+      const isVisible = filter === "all" || category === filter;
+      entry.classList.toggle("is-filtered-out", !isVisible);
+      if (isVisible) visibleCount += 1;
+    }
+
+    if (filterStatus) {
+      filterStatus.textContent =
+        filter === "all"
+          ? `${visibleCount} incidents`
+          : `${visibleCount} ${filter.toLowerCase()}`;
+    }
+
+    if (emptyState instanceof HTMLElement) {
+      emptyState.hidden = visibleCount > 0;
+    }
+
+    updateAlternatingLayout();
   };
 
   if (timeline && orderToggle) {
@@ -186,6 +297,29 @@ const displayedTimelineEvents = [...timelineEvents].reverse();
       );
     });
   }
+
+  for (const button of filterButtons) {
+    button.addEventListener("click", () => {
+      if (!(button instanceof HTMLButtonElement)) return;
+      const nextFilter = button.dataset.filter ?? "all";
+      applyFilter(nextFilter);
+    });
+  }
+
+  timelineSection?.addEventListener("click", (event) => {
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+
+    const pill = target.closest(".timeline-meta-category");
+    if (!pill) return;
+
+    const entry = pill.closest("[data-category]");
+    const category =
+      entry instanceof HTMLElement ? entry.dataset.category : undefined;
+    if (category) applyFilter(category);
+  });
+
+  applyFilter("all");
 
   if (prefersReducedMotion || !("IntersectionObserver" in window)) {
     for (const entry of observedEntries) {

--- a/src/components/Timeline.astro
+++ b/src/components/Timeline.astro
@@ -142,11 +142,14 @@ const displayedTimelineEvents = [...timelineEvents].reverse();
                     >
                       {event.period}
                     </time>
-                    <span
+                    <button
+                      type="button"
                       class={`timeline-meta-category ui-text inline-flex items-center rounded-full border px-2.5 py-px text-sm font-medium leading-4 ${categoryStyles[event.category]}`}
+                      data-category={event.category}
+                      aria-label={`Filter timeline by ${event.category}`}
                     >
                       {event.category}
-                    </span>
+                    </button>
                   </div>
                   <h2 class="timeline-title mt-4 text-[1.7rem] text-balance font-medium leading-[1.14] text-(--ink) md:text-[1.8rem]">
                     <a
@@ -206,7 +209,6 @@ const displayedTimelineEvents = [...timelineEvents].reverse();
     "#timeline-command [data-filter]",
   );
   const filterStatus = document.querySelector("#timeline-filter-status");
-  const emptyState = document.querySelector("#timeline-empty");
   const observedEntries = document.querySelectorAll(".timeline-entry");
   const prefersReducedMotion = window.matchMedia(
     "(prefers-reduced-motion: reduce)",
@@ -279,10 +281,6 @@ const displayedTimelineEvents = [...timelineEvents].reverse();
           : `${visibleCount} ${filter.toLowerCase()}`;
     }
 
-    if (emptyState instanceof HTMLElement) {
-      emptyState.hidden = visibleCount > 0;
-    }
-
     updateAlternatingLayout();
   };
 
@@ -311,11 +309,9 @@ const displayedTimelineEvents = [...timelineEvents].reverse();
     if (!(target instanceof Element)) return;
 
     const pill = target.closest(".timeline-meta-category");
-    if (!pill) return;
+    if (!(pill instanceof HTMLButtonElement)) return;
 
-    const entry = pill.closest("[data-category]");
-    const category =
-      entry instanceof HTMLElement ? entry.dataset.category : undefined;
+    const category = pill.dataset.category;
     if (category) applyFilter(category);
   });
 

--- a/src/lib/event-visuals.ts
+++ b/src/lib/event-visuals.ts
@@ -2,6 +2,14 @@ import type { TimelineEvent } from "@/data/timeline";
 
 export type TimelineCategory = TimelineEvent["category"];
 
+export const timelineCategories = [
+  "Legal",
+  "Quality",
+  "Reliability",
+  "Safety",
+  "Policy",
+] as const satisfies readonly TimelineCategory[];
+
 export const categoryStyles = {
   Legal:
     "border-[color-mix(in_srgb,var(--cat-legal)_45%,transparent)] bg-[color-mix(in_srgb,var(--cat-legal)_6%,transparent)] text-[color-mix(in_srgb,var(--cat-legal)_72%,transparent)]",

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -449,6 +449,17 @@ html.fx-slashing * {
   touch-action: none;
 }
 
+button.timeline-meta-category {
+  margin: 0;
+  font: inherit;
+  appearance: none;
+}
+
+button.timeline-meta-category:focus-visible {
+  outline: 2px solid var(--accent-dark);
+  outline-offset: 3px;
+}
+
 @keyframes fx-wobble {
   0% {
     rotate: 0deg;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -181,7 +181,7 @@ a:focus-visible {
 }
 
 .hero-section {
-  min-height: clamp(20rem, 58svh, 34rem);
+  min-height: clamp(20rem, 54svh, 34rem);
   display: flex;
   align-items: center;
 }
@@ -262,8 +262,84 @@ a:focus-visible {
   border-radius: 3px;
 }
 
-.timeline-toolbar {
-  min-height: 1.5rem;
+.timeline-empty {
+  margin: 0 0 1.5rem;
+  color: var(--muted);
+  font-size: 0.95rem;
+  font-style: italic;
+  text-align: center;
+}
+
+.timeline-filter-link {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.4rem 0.65rem;
+  border: 0;
+  border-radius: 4px;
+  background: none;
+  color: color-mix(in srgb, var(--ink-soft) 82%, transparent);
+  cursor: pointer;
+  font: inherit;
+  line-height: 1.25;
+  text-decoration: underline;
+  text-decoration-color: transparent;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.22em;
+  transition:
+    color 160ms ease,
+    text-decoration-color 160ms ease,
+    background-color 160ms ease;
+}
+
+.timeline-filter-sep {
+  display: inline-block;
+  padding: 0 0.2rem;
+  color: color-mix(in srgb, var(--muted) 88%, transparent);
+  user-select: none;
+}
+
+.timeline-filter-link:hover {
+  color: var(--ink);
+  text-decoration-color: color-mix(in srgb, var(--line) 90%, transparent);
+  background: color-mix(in srgb, var(--ink) 4%, transparent);
+}
+
+.timeline-filter-link[aria-pressed="true"] {
+  color: var(--ink);
+  text-decoration-color: currentColor;
+}
+
+.timeline-filter-link[data-filter="all"][aria-pressed="true"] {
+  color: var(--accent-dark);
+}
+
+.timeline-filter-link[data-category="Legal"][aria-pressed="true"] {
+  color: var(--cat-legal);
+}
+
+.timeline-filter-link[data-category="Quality"][aria-pressed="true"] {
+  color: var(--cat-quality);
+}
+
+.timeline-filter-link[data-category="Reliability"][aria-pressed="true"] {
+  color: var(--cat-reliability);
+}
+
+.timeline-filter-link[data-category="Safety"][aria-pressed="true"] {
+  color: var(--cat-safety);
+}
+
+.timeline-filter-link[data-category="Policy"][aria-pressed="true"] {
+  color: var(--cat-policy);
+}
+
+.timeline-filter-link:focus-visible {
+  outline: 2px solid var(--accent-dark);
+  outline-offset: 3px;
+}
+
+.timeline-entry.is-filtered-out {
+  display: none;
 }
 
 .timeline-spine {
@@ -313,13 +389,13 @@ a:focus-visible {
   stroke-linecap: round;
 }
 
-.timeline-entry:nth-child(odd) .timeline-marker,
-.timeline-entry:nth-child(odd) .timeline-marker-mobile {
+.timeline-entry.is-alternate-left .timeline-marker,
+.timeline-entry.is-alternate-left .timeline-marker-mobile {
   rotate: -8deg;
 }
 
-.timeline-entry:nth-child(even) .timeline-marker,
-.timeline-entry:nth-child(even) .timeline-marker-mobile {
+.timeline-entry.is-alternate-right .timeline-marker,
+.timeline-entry.is-alternate-right .timeline-marker-mobile {
   rotate: 9deg;
 }
 
@@ -334,6 +410,12 @@ a:focus-visible {
   z-index: 60;
   overflow: hidden;
   pointer-events: none;
+}
+
+html.fx-slashing,
+html.fx-slashing * {
+  user-select: none;
+  -webkit-user-drag: none;
 }
 
 .fx-particle {
@@ -355,10 +437,16 @@ a:focus-visible {
 
 .hero-pixel-art,
 .closing-image,
+.incident-layer,
 .timeline-marker,
 .timeline-marker-mobile,
-.timeline-meta-category {
+.timeline-meta-category,
+.hero-correction,
+.affiliate-note {
   cursor: pointer;
+  -webkit-user-drag: none;
+  user-select: none;
+  touch-action: none;
 }
 
 @keyframes fx-wobble {
@@ -750,41 +838,41 @@ html.dark .event-reaction footer img {
     --site-header-height: 65px;
   }
 
-  .timeline-entry:nth-child(odd) .timeline-content {
+  .timeline-entry.is-alternate-left .timeline-content {
     margin-right: calc(50% + 3rem);
     text-align: right;
   }
 
-  .timeline-entry:nth-child(even) .timeline-content {
+  .timeline-entry.is-alternate-right .timeline-content {
     margin-left: calc(50% + 3rem);
   }
 
-  .timeline-entry:nth-child(odd) .timeline-branch {
+  .timeline-entry.is-alternate-left .timeline-branch {
     right: -3rem;
     left: auto;
   }
 
-  .timeline-entry:nth-child(even) .timeline-branch {
+  .timeline-entry.is-alternate-right .timeline-branch {
     left: -3rem;
   }
 
-  .timeline-entry:nth-child(odd) .timeline-meta {
+  .timeline-entry.is-alternate-left .timeline-meta {
     justify-content: flex-end;
   }
 
-  .timeline-entry:nth-child(odd) .timeline-meta-category {
+  .timeline-entry.is-alternate-left .timeline-meta-category {
     order: 1;
   }
 
-  .timeline-entry:nth-child(odd) .timeline-meta-date {
+  .timeline-entry.is-alternate-left .timeline-meta-date {
     order: 2;
   }
 
-  .timeline-entry:nth-child(odd) .timeline-title {
+  .timeline-entry.is-alternate-left .timeline-title {
     margin-left: auto;
   }
 
-  .timeline-entry:nth-child(odd) .timeline-sources {
+  .timeline-entry.is-alternate-left .timeline-sources {
     justify-content: flex-end;
   }
 
@@ -797,11 +885,11 @@ html.dark .event-reaction footer img {
     pointer-events: none;
   }
 
-  .timeline-entry:nth-child(odd) .timeline-visual {
+  .timeline-entry.is-alternate-left .timeline-visual {
     left: calc(50% + 3.25rem);
   }
 
-  .timeline-entry:nth-child(even) .timeline-visual {
+  .timeline-entry.is-alternate-right .timeline-visual {
     right: calc(50% + 3.25rem);
   }
 
@@ -831,11 +919,11 @@ html.dark .event-reaction footer img {
     height: clamp(16rem, 24vw, 26rem);
   }
 
-  .timeline-entry:nth-child(odd) .timeline-visual {
+  .timeline-entry.is-alternate-left .timeline-visual {
     left: calc(50% + 5.5rem);
   }
 
-  .timeline-entry:nth-child(even) .timeline-visual {
+  .timeline-entry.is-alternate-right .timeline-visual {
     right: calc(50% + 5.5rem);
   }
 }


### PR DESCRIPTION
## Summary

- Adds an index line above the timeline for category filtering (`All · Legal · Quality · …`) with count/sort on the right and alternating left/right layout when a filter is active.
- Clicking category pills on entries applies the same filter; empty filters show a clear message.
- Extends FunFx with slash-to-spark interactions on hero, timeline markers, and other FX targets, including time-based tilt animations and particle recycling so rapid slashes stay responsive.

<img width="1426" height="777" alt="image" src="https://github.com/user-attachments/assets/8a546ed6-be7b-45c2-9a22-bba46577741b" />

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pointer-driven “slash” interaction mode for FX, including enhanced animation and click suppression after slashing.
  * Added timeline category filtering with dynamic filter controls, per-entry category buttons, and live incident count/status updates.

* **Improvements**
  * Upgraded the particle/FX engine with smarter spawn capping and optional recycling, plus better FX targeting (including incident layers) and reduced-motion handling.
  * Refined interaction affordances and visuals: updated responsive timeline alternation using classes, improved empty/filter states, and improved hero/timeline touch and selection behavior during slashing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->